### PR TITLE
Add experimental Zapier hook for RTD

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.2",
+  "language": "en-US",
+  "caseSensitive": false,
+  "allowCompoundWords": false,
+  "minWordLength": 2,
+  "dictionaries": ["custom"],
+  "dictionaryDefinitions": [{ "name": "custom", "path": ".dict.txt" }]
+}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,2 @@
-ARG VARIANT
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+# https://hub.docker.com/_/microsoft-vscode-devcontainers
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,9 @@
 {
-    "name": "Python 3",
-    "build": {
-        "dockerfile": "Dockerfile",
-        "context": "..",
-        "args": {
-            "VARIANT": "3",
-        },
-    },
-    "settings": {
-        "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-        "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-        "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-        "python.languageServer": "Pylance",
-        "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-        "python.linting.enabled": true,
-        "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-        "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-        "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-        "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-        "python.linting.pylintEnabled": true,
-        "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-        "python.pythonPath": "/usr/local/bin/python",
-    },
-    "remoteUser": "vscode",
+  "image": "mcr.microsoft.com/vscode/devcontainers/base:debian",
+  // "build": {
+  //   "dockerfile": "Dockerfile"
+  // },
+  "settings": {},
+  "extensions": [],
+  "remoteUser": "vscode"
 }

--- a/.dict.txt
+++ b/.dict.txt
@@ -1,0 +1,9 @@
+b726f01758b17dee47dbf544e7ffe2b80a4fb1a1
+cmp
+commit
+env
+gh
+mrkdwn
+rtd
+usr
+webook

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,23 @@
 root = true
 
 [*]
-end_of_line = lf
-trim_trailing_whitespace = true
-insert_final_newline = true
 charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 79
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = off
+max_line_length = off
+
+[*.sh]
+indent_size = 4
 
 [*.py]
-max_line_length = 79
-indent_style = space
 indent_size = 4
+
+[COMMIT_EDITMSG]
+max_line_length = 72

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,16 +1,17 @@
-# Default state for all rules
 default: true
 
-#  Line length
-# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013
-MD013:
-  # Number of characters
-  line_length: 79
+# Blank line inside blockquote
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md028
+MD028: false
 
-# Dollar signs used before commands without showing output
-# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014
-MD014: false
+# Line length
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013
+MD013: false
 
 # Emphasis used instead of a heading
 # https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md036
 MD036: false
+
+# Inline HTML
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033
+MD033: false

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,4 +1,0 @@
-endOfLine = "lf"
-printWidth = 79
-proseWrap = "always"
-tabWidth = 4

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,5 @@
+bracketSameLine: true
+proseWrap: preserve
+semi: true
+singleQuote: true
+trailingComma: all

--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,66 @@
+# Global configurations
+# http://prospector.landscape.io/en/master/profiles.html
+# -----------------------------------------------------------------------------
+
+strictness: verylow
+doc-warnings: false
+member-warnings: true
+
+# Without this setting, Prospector incorrectly tries to load the Django plugin,
+# which raised an Exception
+autodetect: false
+
+# Module-specific configurations
+# http://prospector.landscape.io/en/master/supported_tools.html
+# -----------------------------------------------------------------------------
+
+# https://www.pylint.org/
+pylint:
+  run: true
+  disable: invalid-name
+
+# https://pep8.readthedocs.io/
+pep8:
+  run: true
+
+# https://launchpad.net/pyflakes
+pyflakes:
+  run: true
+
+# https://github.com/PyCQA/mccabe
+mccabe:
+  run: true
+
+# https://github.com/landscapeio/dodgy
+dodgy:
+  run: true
+
+# https://github.com/PyCQA/pydocstyle
+pep257:
+  run: true
+
+# https://github.com/regebro/pyroma
+pyroma:
+  run: true
+
+# https://github.com/jendrikseipp/vulture
+vulture:
+  run: true
+
+# Use pyflakes instead
+# https://github.com/timothycrosley/frosted
+frosted:
+  run: false
+
+# This project is not ready for static typing
+# https://github.com/python/mypy
+mypy:
+  run: false
+
+# https://github.com/PyCQA/bandit
+bandit:
+  run: true
+
+# Internal check to validate this file
+profile-validator:
+  run: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+  "recommendations": [
+    "bierner.github-markdown-preview",
+    "codezombiech.gitignore",
+    "davidanson.vscode-markdownlint",
+    "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
+    "sandcastle.whitespace",
+    "streetsidesoftware.code-spell-checker",
+    "yzhang.markdown-all-in-one",
+    "timonwong.shellcheck",
+    "foxundermoon.shell-format",
+    "fnando.linter",
+    "ms-azuretools.vscode-docker"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/slack/rtd/examples/incoming.json
+++ b/slack/rtd/examples/incoming.json
@@ -1,0 +1,11 @@
+{
+  "event": "{{ event }}",
+  "name": "{{ project.name }}",
+  "slug": "{{ project.slug }}",
+  "version": "{{ version.slug }}",
+  "commit": "{{ build.commit }}",
+  "build": "{{ build.id }}",
+  "start_date": "{{ build.start_date }}",
+  "build_url": "{{ build.url }}",
+  "docs_url": "{{ build.docs_url }}"
+}

--- a/slack/rtd/test.sh
+++ b/slack/rtd/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -e
+
+# Test the `zapier.py` by posting the result to a Slack webhook (defined by the
+# `SLACK_APP_RTD_WEBOOK_TEST` environment variable)
+
+python3 zapier.py |
+    curl -H 'Content-type: application/json' \
+        -X POST --data-binary @- "${SLACK_APP_RTD_WEBOOK_TEST}"
+
+# The HTTP response body lacks a final newline so we add one manually
+printf '\n'

--- a/slack/rtd/zapier.py
+++ b/slack/rtd/zapier.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+"""Transform Read The Docs webhook data into Slack webhook data
+
+This script is used By Zapier to transform the webhook data sent by Read The
+Docs into data that can be sent to Slack.
+"""
+
+import json
+
+GH_ORG = "doitintl"
+GH_REPO = "docs-sphinx-cmp"
+GH_REPO_URL = f"https://github.com/{GH_ORG}/{GH_REPO}"
+RTD_ORG = "doit-international"
+RTD_PROJECTS = "readthedocs.com/projects"
+RTD_SLUG = f"{RTD_ORG}-{GH_REPO}"
+SLACK_FAVICON = "https://slack.github.com/static/img/favicon-neutral.png"
+
+# From the Read The Docs documentation, we expect the incoming webhook data to
+# look like the `examples/incoming.json` file.
+
+# In Zapier, we map the  webhook data a dict with the structure below. The
+# conditional creates the dict with some example values so we that can test
+# this script without any input data.
+if "input_data" not in locals():
+    input_data = {
+        "event": "build:passed",
+        "name": GH_REPO,
+        "slug": RTD_SLUG,
+        "version": "latest",
+        "commit": "b726f01758b17dee47dbf544e7ffe2b80a4fb1a1",
+        "build": "783488",
+        "start_date": "2021-11-25T17:26:39",
+        "build_url": f"https://{RTD_PROJECTS}/{RTD_SLUG}/builds/783488/",
+        "docs_url": f"https://{RTD_SLUG}.readthedocs-hosted.com/en/latest/",
+    }
+
+
+def main():
+    """Handle the input dict and return an output dict."""
+
+    build_str = f"Build <{input_data['build_url']}|{input_data['build']}>"
+
+    commit_str = ""
+    # The `commit` key may be an empty string (e.g. when a build is triggered
+    # by hand instead of from an incoming GitHub webhook)
+    if input_data["commit"]:
+        commit_url = f"{GH_REPO_URL}/commit/{input_data['commit']}"
+        # GitHub trims commit hashes to seven characters
+        commit_short = input_data["commit"][:7]
+        commit_str = f"for commit <{commit_url}|{commit_short}>"
+
+    color = ""
+    message = ""
+    if input_data["event"] == "build:triggered":
+        color = "warning"
+        message = f"{build_str} triggered {commit_str}"
+    if input_data["event"] == "build:failed":
+        color = "danger"
+        message = f"{build_str} failed {commit_str}"
+    if input_data["event"] == "build:passed":
+        color = "good"
+        message = f"{build_str} passed {commit_str}"
+
+    footer = f"<{input_data['docs_url']}|{input_data['docs_url']}>"
+
+    json_dict = {
+        "attachments": [
+            {
+                "text": message,
+                "fallback": "",
+                "pretext": "",
+                "color": color,
+                "mrkdwn_in": ["text"],
+                "footer": footer,
+                "footer_icon": SLACK_FAVICON,
+            }
+        ]
+    }
+
+    return {"json": json.dumps(json_dict, indent=4, sort_keys=True)}
+
+
+if __name__ == "__main__":
+    output = main()
+    print(output["json"])


### PR DESCRIPTION
The new `slack/rtd/zapier.py` file is a first attempt at handling incoming webhooks from RTD. When a webhook is received, this script generates a payload that can be sent to a Slack application, resulting in a channel notification.

Additionally, this commit adds some minor quality of life improvements for this repository.