### PR TITLE
Switch to a universal DocOps devcontainer

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -15,13 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cd docops-containers && make check
-  build:
-    name: Build ${{ matrix.image }}
+  build-devcontainer:
+    name: Build devcontainer
     needs: checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        image: [dev, dev-python]
     steps:
       - uses: actions/checkout@v2
       # TODO: Add file changed test back again and add `fetch-depth: 0` to
@@ -29,7 +26,7 @@ jobs:
       - uses: docker/metadata-action@v3
         id: meta
         with:
-          images: ghcr.io/${{ github.repository }}/${{ matrix.image }}
+          images: ghcr.io/${{ github.repository }}/devcontainer
           github-token: ${{ github.token }}
       - uses: docker/login-action@v1
         if: github.event_name != 'pull_request'
@@ -40,14 +37,13 @@ jobs:
       - uses: docker/build-push-action@v2
         id: build
         with:
-          build-args: VARIANT=${{ matrix.image }}
           context: docops-containers/src
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
-  notify:
-    name: Notify
-    needs: build
+  notification:
+    name: Notifcation
+    needs: build-devcontainer
     if: always() && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:

--- a/docops-containers/.gitignore
+++ b/docops-containers/.gitignore
@@ -1,1 +1,2 @@
 .vscode/settings.json
+tmp

--- a/docops-containers/src/Dockerfile
+++ b/docops-containers/src/Dockerfile
@@ -22,6 +22,6 @@ ENV PIPX_BIN_DIR=/usr/local/bin
 COPY . /tmp/checkout
 WORKDIR /tmp/checkout
 RUN ./bootstrap.sh && \
-  make -f build/rules/devcontainer.mk $VARIANT && \
+  make && \
   ./clean.sh && \
   rm -rf /tmp/checkout

--- a/docops-containers/src/Makefile
+++ b/docops-containers/src/Makefile
@@ -9,23 +9,19 @@
 # POSIX locale
 LC_ALL = C
 
-RULES_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-INSTALL_RULES = $(RULES_DIR)/install.mk
+SRC_DIR := $(subst /,,$(dir $(lastword $(MAKEFILE_LIST))))
+BUILD_DIR := $(SRC_DIR)/build
+TMP_DIR := $(BUILD_DIR)/tmp
+RULES := $(BUILD_DIR)/rules.mk
 
-INSTALL = $(MAKE) --no-print-directory -f $(INSTALL_RULES)
+MAKE_RULES := $(MAKE) --no-print-directory -f $(RULES)
 
-# Targets
-# =============================================================================
-
-# dev
-# -----------------------------------------------------------------------------
-
-DEV_DEPS = \
+BUILD_DEPS = \
 	bashrc \
 	brok \
 	build-essential \
-	cspell \
 	codespell \
+	cspell \
 	dockerfilelint \
 	doitintl-docops \
 	ec \
@@ -41,6 +37,7 @@ DEV_DEPS = \
 	optipng \
 	pandoc \
 	parallel \
+	poetry \
 	prettier \
 	proselint \
 	shellcheck \
@@ -49,21 +46,28 @@ DEV_DEPS = \
 	vale \
 	yamllint
 
-.PHONY: dev
-dev:
-	@ $(INSTALL) $(DEV_DEPS)
-
-# dev-python
-# -----------------------------------------------------------------------------
-
-DEV_PYTHON_DEPS = poetry
-
-.PHONY: dev-python
-dev-python: dev
-	@ $(INSTALL) $(DEV_PYTHON_DEPS)
-
-# Default goal
+# Targets
 # =============================================================================
 
-# Clears the default goal, causing an error if no target is specified
-.DEFAULT_GOAL =
+.DEFAULT_GOAL := build
+
+.PHONY: list
+list:
+	@$(BUILD_DIR)/list.sh
+
+.PHONY: list
+list-check:
+	@$(BUILD_DIR)/list.sh --check
+
+.PHONY: build
+build: $(BUILD_DEPS)
+
+.PHONY: clean
+clean:
+	rm -rf $(TMP_DIR)
+
+# Pattern rules
+# =============================================================================
+
+%:
+	@ $(MAKE_RULES) $@

--- a/docops-containers/src/build/list.sh
+++ b/docops-containers/src/build/list.sh
@@ -9,9 +9,7 @@ BOLD=[1m
 RESET=[0m
 
 BUILD_DIR=$(dirname "${0}")
-RULES_DIR="rules"
-DEVCONTAINER_RULES="${BUILD_DIR}/${RULES_DIR}/devcontainer.mk"
-INSTALL_RULES="${BUILD_DIR}/${RULES_DIR}/install.mk"
+RULES="${BUILD_DIR}/rules.mk"
 
 get_targets() {
     file="${1}"
@@ -21,7 +19,7 @@ get_targets() {
 
 format_targets() {
     basename="${1}"
-    command="make -f ${RULES_DIR}/${basename} \x1b${BOLD}\1\x1b${RESET}"
+    command="make -f ${BUILD_DIR}/${basename} \x1b${BOLD}\1\x1b${RESET}"
     sed -E "s,(.*),  ${command}," </dev/stdin
 
 }
@@ -42,17 +40,15 @@ check_sort() {
 print_targets() {
     file="${1}"
     basename="$(basename "${file}")"
-    echo "Available targets for \`${basename}\` file:"
+    stem="$(echo "${basename}" | cut -f 1 -d '.')"
+    echo "Available ${stem}:"
     echo
     get_targets "${file}" | sort |
         format_targets "${basename}"
 }
 
 if test "${1}" = "--check"; then
-    check_sort "${DEVCONTAINER_RULES}"
-    check_sort "${INSTALL_RULES}"
+    check_sort "${RULES}"
 else
-    print_targets "${DEVCONTAINER_RULES}"
-    echo
-    print_targets "${INSTALL_RULES}"
+    print_targets "${RULES}"
 fi

--- a/docops-containers/src/build/reset.sh
+++ b/docops-containers/src/build/reset.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-
-BUILD_DIR=$(dirname "${0}")
-TMP_DIR="${BUILD_DIR}/tmp"
-
-rm -rf "${TMP_DIR}"

--- a/docops-containers/src/build/rules.mk
+++ b/docops-containers/src/build/rules.mk
@@ -14,8 +14,7 @@ BOLD = [1m
 RED = [31m
 RESET = [0m
 
-RULES_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
-BUILD_DIR := $(shell realpath --relative-to "$$(pwd)" $(RULES_DIR)/..)
+BUILD_DIR := $(subst /,,$(dir $(lastword $(MAKEFILE_LIST))))
 TEMPLATES_DIR := $(BUILD_DIR)/templates
 TMP_DIR := $(BUILD_DIR)/tmp
 


### PR DESCRIPTION
Previously, we were building two separate devcontainers: `dev` and `dev-python`. Because there isn't much overhead for the Python devcontainer, unifying the images will make the code easier to maintain.