### PR TITLE
Switch project to new universal devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "ghcr.io/doitintl/docops-containers/dev:main",
+  "image": "ghcr.io/doitintl/docops/devcontainer:main",
   "settings": {},
   "extensions": [],
   "remoteUser": "vscode"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Checks
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/doitintl/docops-containers/dev:main
+      image: ghcr.io/doitintl/docops/devcontainer:main
     steps:
       - uses: actions/checkout@v2
       - run: cd docops-containers && make check


### PR DESCRIPTION
Now that the universal DocOps devcontainer image has been published as a project package, this commit switched the project to use the new image.