### PR TITLE
Add Black for Python formatting

### DIFF
--- a/docops-containers/src/Makefile
+++ b/docops-containers/src/Makefile
@@ -18,6 +18,7 @@ MAKE_RULES := $(MAKE) --no-print-directory -f $(RULES)
 
 BUILD_DEPS = \
 	bashrc \
+	black \
 	brok \
 	build-essential \
 	codespell \

--- a/docops-containers/src/build/rules.mk
+++ b/docops-containers/src/build/rules.mk
@@ -134,6 +134,15 @@ bashrc: apt-bash-completion apt-gawk
 	$(call touch_file,$(USER),$(USER_HOME)/$(WILL_CITE))
 	$(call touch_file,$(USER),$(USER_HOME)/$(FIRST_RUN))
 
+# black
+# -----------------------------------------------------------------------------
+
+# Black
+# https://github.com/psf/black
+
+.PHONY: black
+black: pipx-black
+
 # brok
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit adds the `black` pipx package so we can format Python code outside of a Python virtual environment. A globally available Black installation is necessary for editor and IDE functionality (e.g., VS Code).