### PR TITLE
Add ImageMagick for image processing

### DIFF
--- a/docops-containers/src/Makefile
+++ b/docops-containers/src/Makefile
@@ -29,6 +29,7 @@ BUILD_DEPS = \
 	file \
 	hadolint \
 	html-minifier \
+	imagemagick \
 	imgdup2go \
 	lintspaces-cli \
 	markdown-link-check \

--- a/docops-containers/src/build/rules.mk
+++ b/docops-containers/src/build/rules.mk
@@ -283,6 +283,14 @@ hadolint:
 .PHONY: html-minifier
 html-minifier: npm-html-minifier
 
+# imagemagick
+# -----------------------------------------------------------------------------
+
+# https://github.com/ImageMagick/ImageMagick
+
+.PHONY: imagemagick
+imagemagick: apt-imagemagick
+
 # imgdup2go
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit adds the `imagemagick` APT package to the devcontainer so that contributors can manipulate images when necessary (e.g., converting to a different format).