### PR TITLE
Install `tree` utility

### DIFF
--- a/buildx/devcontainer/Makefile
+++ b/buildx/devcontainer/Makefile
@@ -49,6 +49,7 @@ PREP_DEPS = \
 	shfmt \
 	textlint \
 	tidy \
+	tree \
 	vale \
 	yamllint \
 	yarn

--- a/buildx/devcontainer/prep/rules.mk
+++ b/buildx/devcontainer/prep/rules.mk
@@ -502,6 +502,14 @@ textlint: $(TEXTLINT_DEPS)
 .PHONY: tidy
 tidy: apt-tidy
 
+# tree
+# -----------------------------------------------------------------------------
+
+# http://mama.indstate.edu/users/ice/tree/
+
+.PHONY: tree
+tree: apt-tree
+
 # vale
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
This commit installs the `tree` utility into the DocOps devcontainer, which can be used to generate HTML index pages.